### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^7.0",
         "fzaninotto/faker": "^1.6",
-        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
-        "illuminate/database": "~5.4.0|~5.5.x-dev"
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/database": "~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.7",
-        "orchestra/database": "~3.4.0@dev|~3.5.x-dev",
-        "orchestra/testbench": "~3.4.0@dev|~3.5.x-dev",
+        "orchestra/database": "~3.4.0@dev|~3.5.x-dev|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.0@dev|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -51,3 +51,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     "require": {
         "php": "^7.0",
         "fzaninotto/faker": "^1.6",
-        "illuminate/contracts": "~5.4.0",
-        "illuminate/database": "~5.4.0"
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
+        "illuminate/database": "~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.7",
-        "orchestra/database": "~3.4.0@dev",
-        "orchestra/testbench": "~3.4.0@dev",
-        "phpunit/phpunit": "5.*"
+        "orchestra/database": "~3.4.0@dev|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.0@dev|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-mailable-test/phpunit.xml.dist

................                                                  16 / 16 (100%)

Time: 4.3 seconds, Memory: 18.00MB

OK (16 tests, 41 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments