### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/database": "~5.5.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.7",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.5.0",
         "phpunit/phpunit": "^6.3"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).