### PR TITLE
Switch to use "fakerphp/faker"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2",
-        "fzaninotto/faker": "^1.9",
+        "fakerphp/faker": "^1.9.1",
         "illuminate/contracts": "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/database": "~5.8.0|^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
For some reasons my fakerphp/faker is stuck at 1.9 when I run composer outdated

When i try to change fakerphp/faker in my project to the latest stable (i.e. ^1.12.1), composer throw an error and mentioned this package.

"fakerphp/faker": "^1.9.1", is what is currently listed in laravel/laravel composer.json file